### PR TITLE
Default to javascript when no lang attribute is found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default declare(
               ignoreAttributes: false
             });
 
-            if(typeof json.script !== "undefined" && typeof json.script["@_lang"] && json.script["@_lang"].toLowerCase() === "ts") {
+            if(json.script && typeof json.script === "object" && typeof json.script["@_lang"] === "string" && json.script["@_lang"].toLowerCase() === "ts") {
               return true;
             }
 


### PR DESCRIPTION
First of all, thanks for the preset. Without it I'd probably stopped here and passed on making class-based components and Typescript work together.

It seems, however, it does not handle well cases when there are no attributes present on `script` tag in `.vue` file, in which `fast-xml-parser` returns the inner text of the node as string instead of the object.

![](http://i.imgur.com/voc0Yis.png)

On quick glance I haven't found the option to force it to always return object, so adding extra typechecks is probably the simplest way.