### PR TITLE
Remove restriction on preset options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,7 @@ This preset checks whether the .vue file (SFC) has a `lang="ts"` attribute set f
 
 All the options match the original [@babel/preset-typescript](https://babeljs.io/docs/en/next/babel-preset-typescript.html) preset options.
 
-- `isTSX` (boolean, defaults to `false`)
-
-  Forcibly enables jsx parsing. Otherwise angle brackets will be treated as typescript's legacy type assertion `var foo = <string>bar;`. Also, `isTSX: true` requires `allExtensions: true`
-
-- `jsxPragma` (string, defaults to `React`)
-
-  Replace the function used when compiling JSX expressions.
-
-  This is so that we know that the import is not a type import, and should not be removed
-
-- `allExtensions` (boolean, defaults to `false`)
-
-  Indicates that every file should be parsed as TS or TSX (depending on the isTSX option)
-
-  > You can read more about configuring preset options [here](https://babeljs.io/docs/en/presets#preset-options)
+You can read more about configuring preset options [here](https://babeljs.io/docs/en/presets#preset-options)
 
 ## Original notes and issues
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,13 @@ import presetTypeScript from "@babel/preset-typescript";
 
 
 export default declare(
-  (api, { jsxPragma, allExtensions = false, isTSX = false }) => {
+  (api, options = {}) => {
 
     api.assertVersion(7);
 
     return {
       "presets": [
-        [presetTypeScript, { jsxPragma, allExtensions, isTSX }]
+        [presetTypeScript, options]
       ],
       "overrides": [{
         "test": filePath => {
@@ -33,11 +33,7 @@ export default declare(
 
         },
         "plugins": [
-          [pluginTransformTypeScript, {
-            jsxPragma,
-            allExtensions,
-            isTSX
-          }]
+          [pluginTransformTypeScript, options]
         ]
       }]
     };


### PR DESCRIPTION
The PR allows the preset to accept arbitrary set of options by removing hardcoded defaults. Previously, specifying allowNamespaces, allowDeclareFields or onlyRemoveTypeImports had no desired effect. And, since the options are identical, the explicit list can probably be removed from README as well.